### PR TITLE
[WEB-9239] Clean streeteasy address by removing extra spaces

### DIFF
--- a/src/parsers/StreetEasyParser.js
+++ b/src/parsers/StreetEasyParser.js
@@ -3,7 +3,6 @@ import isEmpty from 'lodash/isEmpty'
 import startCase from 'lodash/startCase'
 import isNaN from 'lodash/isNaN'
 import intersection from 'lodash/intersection'
-import words from 'lodash/words'
 import $ from 'jquery'
 import { UNIT_AMENITIES_LIST, SOURCES_MAP, STREET_EASY_AMENITIES_MAP } from '../constants'
 
@@ -26,7 +25,7 @@ export default class StreetEasyParser {
       []
 
     const zip = get(compData, 'listZip')
-    const address = words($('.backend_data.BuildingInfo-item').text()).join(' ')
+    const address = $('.backend_data.BuildingInfo-item').text().trim().replace(/\n/g, ' ').replace(/\s+/g, ' ')
 
     const result = {
       dateOfValue: this.dateOfValue,


### PR DESCRIPTION
https://bowery.atlassian.net/browse/WEB-9239

I don't know what else words().join(' ') was intended to do. In fact, I'm only assuming it was meant to do this. What I know it was doing is replacing '-'s with spaces, so 26-22 4th Street got turned to 26 22 4th Street. 2622 4th Street is the same as the address we want, at least in Astoria, but 26 22 4th Street is different and does not exist.

This continues to work for named buildings like https://streeteasy.com/building/the-century/2505.
It works for  [1200 Avenue at Port Imperial](https://streeteasy.com/building/1200-avenue-at-port-imperial-weehawken/0504)  Weehawken, New Jersey.
This is weird, but I'm assuming it's working for https://streeteasy.com/building/the-landings-at-port-imperial/1115.

It continues to not work for buildings that are part of a named complex, like https://streeteasy.com/building/waterside-square-north-at-newport/1912.