### PR TITLE
[WEB-9634] Save coordinates and number of bathrooms to CompPlex

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bowery-chrome-extension",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "Chrome extension for Bowery appraisers using the Bowery Authorship Application.",
   "scripts": {
     "build": "node scripts/build.js",

--- a/src/services/CompPlexService.js
+++ b/src/services/CompPlexService.js
@@ -49,6 +49,10 @@ class CompPlexService {
         city: unitCompData.city,
         state: unitCompData.state,
         postalCode: unitCompData.zip,
+        coords: {
+          latitude: get(unitCompData, 'coords.latitude'),
+          longitude: get(unitCompData, 'coords.longitude'),
+        },
       },
       leaseDate: unitCompData.dateOfValue,
       unitNumber: unitCompData.unitNumber,
@@ -59,6 +63,7 @@ class CompPlexService {
         unitAmenities: unitCompData.amenities.map(mapAmenity),
         unitType: unitCompData.unitLayout ? camelCase(unitCompData.unitLayout) : null,
         unitSquareFootage: unitCompData.sqft,
+        numberOfBathrooms: String(unitCompData.bathrooms),
       },
       resourceInformation: {
         sources: [


### PR DESCRIPTION
Other data that we used to send to Webapp in 2.3 that we no longe save include:
- rooms: CompPlex doesn't have a field for this
- sourceName: This is derived from sourceOfInformation & sourceUrl
- locationIdentifier, block, lot, borough, qualifier: a little complicated & not required
- chromeExtensionVersion: I'll update Webapp to keep this (https://github.com/Bowery-RES/Webapp/pull/9193)
- pricePerSqft, report: I don't believe they were actually used