### PR TITLE
[WEB-9606] Don't throw error when getting property data fails

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bowery-chrome-extension",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "Chrome extension for Bowery appraisers using the Bowery Authorship Application.",
   "scripts": {
     "build": "node scripts/build.js",

--- a/src/services/BoweryService.js
+++ b/src/services/BoweryService.js
@@ -107,7 +107,7 @@ class BoweryService {
     } catch (error) {
       // eslint-disable-next-line no-console
       console.log(error)
-      throw error
+      return {}
     }
   }
 


### PR DESCRIPTION
https://bowery.atlassian.net/browse/WEB-9606

Throwing the error here prevents us from pre-populating the fields we can get from the page
Also bump patch version